### PR TITLE
Corrections for D1 compiler

### DIFF
--- a/conversion/dlang.d
+++ b/conversion/dlang.d
@@ -432,7 +432,6 @@ unittest {
 	// Optional messages don't ser if missing issue #27
 	auto str = ParserData("optional SomeMessage sm = 2;");
 	child = PBChild(str);
-	import std.stdio;
 	mixin(`enum one = ParserData("message AnyLineDescriptor {
                                  optional SomeMessage m2 = 2; }");`);
 	mixin(`enum two = ParserData("message SomeMessage {}");`);

--- a/conversion/pbbinary.d
+++ b/conversion/pbbinary.d
@@ -359,7 +359,7 @@ ubyte[]ripUField(ref ubyte[]input,int wiretype) {
 /**
  * Handle packed fields.
  */
-ubyte[]toPacked(T:T[],alias serializer)(const T[] packed,int field) {
+ubyte[]toPacked(T:T[],alias serializer)(in T[] packed,int field) {
 	// zero length packed repeated fields serialize to nothing
 	if (!packed.length) return null;
 	ubyte[]ret;


### PR DESCRIPTION
Found that I wasn't building the library on previous tests. This address issues with D1 and const. Plus unneeded import.
