### PR TITLE
CTFE and extension fixes

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -13,9 +13,11 @@ dependency "protocolbuffer:wireformat" version="*"
 configuration "dprotobuf" {
 		targetName "dprotobuf"
 		targetType "library"
+		excludedSourceFiles "source/app.d"
 }
 configuration "unittest" {
 		subConfiguration "codebuilder" "FileWriter"
+		excludedSourceFiles "source/app.d"
 }
 configuration "pbcompiler" {
 		targetName "pbcompiler"

--- a/source/dprotobuf/generator/dlang.d
+++ b/source/dprotobuf/generator/dlang.d
@@ -43,7 +43,7 @@ private string typeWrapper(PBChild child) {
 		return format("Nullable!(%s) ", toDType(child.type));
 }
 
-string langD(PBRoot root) {
+string langD(PBRoot root, bool markMessagesAsStatic = false) {
 	auto code = CodeBuilder(0);
     code.put("import dprotobuf.wireformat;\n");
     code.put("import std.conv;\n");
@@ -61,7 +61,7 @@ string langD(PBRoot root) {
     }
     // write out message definitions
     foreach(pbmsg; root.message_defs) {
-        code.put(toD(pbmsg, 0));
+        code.put(toD(pbmsg, 0, markMessagesAsStatic));
     }
     return code.finalize();
 }
@@ -616,13 +616,13 @@ string genMerge(PBMessage msg, int indentCount = 0) {
 
 /**
  */
-string toD(PBMessage msg, int indentCount = 0) {
+string toD(PBMessage msg, int indentCount = 0, bool staticChild = false) {
 	auto indent = indented(indentCount);
 	string ret = "";
 	with(msg) {
 		ret ~= addComments(comments).finalize();
 
-		ret ~= indent~(indent.length?"static ":"")~"struct "~name~" {\n";
+		ret ~= indent~(staticChild?"static ":"")~"struct "~name~" {\n";
 		indent = indented(++indentCount);
 		ret ~= indent~"// deal with unknown fields\n";
 		ret ~= indent~"ubyte[] ufields;\n";
@@ -634,7 +634,7 @@ string toD(PBMessage msg, int indentCount = 0) {
 		}
 		// now, we'll do the nested messages
 		foreach(pbmsg;message_defs) {
-			ret ~= toD(pbmsg, indentCount);
+			ret ~= toD(pbmsg, indentCount, true);
 			ret ~= "\n\n";
 		}
 		// do the individual instantiations

--- a/source/dprotobuf/generator/dlang.d
+++ b/source/dprotobuf/generator/dlang.d
@@ -38,9 +38,9 @@ import std.string : format;
  */
 private string typeWrapper(PBChild child) {
 	if(child.modifier == "repeated")
-		return format("Nullable!(%s[])", toDType(child.type));
+		return format("Nullable!(%s[]) ", toDType(child.type));
 	else
-		return format("Nullable!(%s)", toDType(child.type));
+		return format("Nullable!(%s) ", toDType(child.type));
 }
 
 string langD(PBRoot root) {
@@ -78,7 +78,6 @@ string toD(PBChild child, int indentCount = 0) {
 		if(is_dep) code.put("deprecated ref ");
 		else code.put("");
 		code.rawPut(typeWrapper(child));
-		code.rawPut(" ");
 		code.rawPut(name);
 		if(isReserved(name))
 			code.rawPut("_");
@@ -89,7 +88,7 @@ string toD(PBChild child, int indentCount = 0) {
 			code.pop();
 			code.put("private ");
 			code.rawPut(typeWrapper(child));
-			code.put(" " ~ name ~ "_dep");
+			code.put(name ~ "_dep");
 		}
 		if(!empty(valdefault)) // Apply default value
 			code.rawPut(" = " ~ valdefault);

--- a/source/dprotobuf/pbchild.d
+++ b/source/dprotobuf/pbchild.d
@@ -21,49 +21,6 @@ struct PBChild {
 	bool packed = false;
 	bool is_dep = false;
 
-	string genExtenCode(string indent) {
-		string ret;
-		ret ~= indent~(is_dep?"deprecated ":"")~toDType(type)~(modifier=="repeated"?"[]":" ")~"__exten_"~name~(valdefault.length?" = "~valdefault:"")~";\n";
-		// get accessor
-		ret ~= indent~(is_dep?"deprecated ":"")~toDType(type)~(modifier=="repeated"?"[]":" ")~"GetExtension(int T:"~to!(string)(index)~")() {\n";
-		ret ~= indent~"	return __exten_"~name~";\n";
-		ret ~= indent~"}\n";
-		// set accessor
-		ret ~= indent~(is_dep?"deprecated ":"")~"void SetExtension(int T:"~to!(string)(index)~")("~toDType(type)~(modifier=="repeated"?"[]":" ")~"input_var) {\n";
-		ret ~= indent~"	__exten_"~name~" = input_var;\n";
-		if (modifier != "repeated") ret ~= indent~"	_has__exten_"~name~" = true;\n";
-		ret ~= indent~"}\n";
-		if (modifier == "repeated") {
-			ret ~= indent~(is_dep?"deprecated ":"")~"bool HasExtension(int T:"~to!(string)(index)~")() {\n";
-			ret ~= indent~"	return __exten_"~name~".length?1:0;\n";
-			ret ~= indent~"}\n";
-			ret ~= indent~(is_dep?"deprecated ":"")~"void ClearExtension(int T:"~to!(string)(index)~")() {\n";
-			ret ~= indent~"	__exten_"~name~" = null;\n";
-			ret ~= indent~"}\n";
-			// technically, they can just do class.item.length
-			// there is no need for this
-			ret ~= indent~(is_dep?"deprecated ":"")~"int ExtensionSize(int T:"~to!(string)(index)~")() {\n";
-			ret ~= indent~"	return __exten_"~name~".length;\n";
-			ret ~= indent~"}\n";
-			// functions to do additions, both singular and array
-			ret ~= indent~(is_dep?"deprecated ":"")~"void AddExtension(int T:"~to!(string)(index)~")("~toDType(type)~" __addme) {\n";
-			ret ~= indent~"	__exten_"~name~" ~= __addme;\n";
-			ret ~= indent~"}\n";
-			ret ~= indent~(is_dep?"deprecated ":"")~"void AddExtension(int T:"~to!(string)(index)~")("~toDType(type)~"[]__addme) {\n";
-			ret ~= indent~"	__exten_"~name~" ~= __addme;\n";
-			ret ~= indent~"}\n";
-		} else {
-			ret ~= indent~"bool _has__exten_"~name~" = false;\n";
-			ret ~= indent~(is_dep?"deprecated ":"")~"bool HasExtension(int T:"~to!(string)(index)~")() {\n";
-			ret ~= indent~"	return _has__exten_"~name~";\n";
-			ret ~= indent~"}\n";
-			ret ~= indent~(is_dep?"deprecated ":"")~"void ClearExtension(int T:"~to!(string)(index)~")() {\n";
-			ret ~= indent~"	_has__exten_"~name~" = false;\n";
-			ret ~= indent~"}\n";
-		}
-		return ret;
-	}
-
 	static PBChild opCall(ref ParserData pbstring)
 	in {
 		assert(pbstring.length);


### PR DESCRIPTION
There were some bugs when adding extensions to a message. But the primary purpose of this is to make it possible to mixin a proto file as D code. Something like:

mixin(PBRoot(import("myfile.proto")).langD);

It is also possible to apply extensions to PBRoot but that will need to happen manually as it won't/can't follow imports.

Known issues:
- Imports are not ignored causing failures to compile since those proto files won't be compiled in.
- Can't mixin more than one root, translating to D will define a top level function and this can't be defined multiple times.
